### PR TITLE
Make single and list entries match.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,9 @@
 {{ partial "content-header" . }}
 <article>
+    <header>
+        <h1>{{ .Title }}</h1>
+        <p class="sub">Published on {{ .Date.Format (.Site.Params.dateFormat | default "2006-01-02") }}</p>
+    </header>
     <section>
         {{ .Content }}
         {{/* TODO(cfunkhouser): Related. */}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,9 +2,10 @@
   {{ if .Site.Menus.main }}
   <div>
     <p>{{ if .Site.Params.whoami }}I am {{ .Site.Params.whoami }}. {{ end }}
-      I do write
+      I do
       {{ range $index, $element := .Site.Menus.main }}
-      {{if $index}} and {{end}}<a href="{{ $element.URL }}">{{ $element.Name }}</a>{{end}}.
+      {{ if $index }} and {{ end }}
+      <a href="{{ $element.URL }}">{{ $element.Name }}</a>{{ end }}.
     </p>
   </div>
   {{ end }}

--- a/layouts/partials/list-entry.html
+++ b/layouts/partials/list-entry.html
@@ -2,7 +2,7 @@
   {{ .Date.Format (.Site.Params.dateFormat | default "2006-01-02") | $.Scratch.Set "date" }}
   {{ with .Description }} {{ $.Scratch.Set "subtitle" . }} {{ end }}
   <h1><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
-  <p class="sub">{{ $.Scratch.Get "subtitle" }} Published {{ $.Scratch.Get "date" }}</p>
+  <p class="sub">{{ $.Scratch.Get "subtitle" }} Published on {{ $.Scratch.Get "date" }}</p>
   <p class="sub">
     {{ range $index, $tag := .Params.tags }}
     {{ if $index }} : {{ end }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -86,7 +86,7 @@ article h5,
 article h6 {
   color: #666;
 }
-.list-item .sub {
+.sub {
   padding: 0;
   margin: 0;
   color: #666;


### PR DESCRIPTION
The heading for a single content entry should match the styling of the list entries. Make that true.